### PR TITLE
 automatic clearing of small dirt nodes when players walk over them

### DIFF
--- a/game/input.js
+++ b/game/input.js
@@ -428,6 +428,22 @@ function blurActiveElement() {
     }
 }
 
+function handleMovement(dx, dy) {
+  // Existing movement logic
+  player.pos.x += dx * moveSpeed;
+  player.pos.y += dy * moveSpeed;
+
+  // Clear dirt after moving
+  clearDirtAroundPlayer();
+
+  // Sync position with server
+  socket.emit('update_pos', {
+    id: curPlayer.id,
+    pos: player.pos,
+    holding: curPlayer.holding
+  });
+}
+
 function mouseReleased(){
 
     if(gameState == "chating"){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Holes_Client",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This PR implements automatic clearing of small dirt nodes when players walk over them, improving gameplay fluidity. 

Key changes:

- Adds dirt-clearing logic triggered by player movement
- Syncs with existing socket system for multiplayer
 
Changes:

- Added clearDirtAroundPlayer() in diggingFunctions.js
- Modified input.js:  

Related Issue: #40
![image](https://github.com/user-attachments/assets/869cc6db-4ce3-4e8e-b6ef-845a239ba908)
